### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:2
+
+ARG git_commit=master
+
+RUN cd /opt && \
+  git clone https://github.com/Netflix/flamescope && \
+  cd flamescope && \
+  git checkout ${git_commit} && \
+  rm -rf .git && \
+  pip install -r requirements.txt && \
+  mkdir /stacks && \
+  sed -i -e s/127.0.0.1/0.0.0.0/g -e s~examples~/stacks~g app/config.py
+
+WORKDIR "/opt/flamescope"
+ENTRYPOINT ["python", "run.py"]
+EXPOSE 5000/tcp


### PR DESCRIPTION
Small Dockerfile to package flamescope for docker.
Flamescope can be started with:

  docker build -t flamescope .
  docker run -p 5000:5000 -v /local/stacks/dir:/stacks:ro flamescope

Made it for me personally but might also be interesting for others. 
Can also form the base to release an official image to the docker hub.