### PR TITLE
Use gzip python lib instead of guzip system bin

### DIFF
--- a/app/util/heatmap.py
+++ b/app/util/heatmap.py
@@ -20,6 +20,7 @@
 from ..common import fileutil
 import os
 import re
+import gzip
 import collections
 from os.path import abspath, join
 from math import ceil, floor
@@ -62,9 +63,9 @@ def read_offsets(filename):
     # read .gz files via a "gunzip -c" pipe
     if filename.endswith(".gz"):
         try:
-            f = os.popen("gunzip -c " + path)
+            f = gzip.open(path, 'rt')
         except Exception:
-            print("ERROR: Can't gunzip -c stack file %s." % path)
+            print("ERROR: Can't open gzipped file %s." % path)
             f.close()
             return abort(500)
     else:

--- a/app/util/stack.py
+++ b/app/util/stack.py
@@ -19,6 +19,7 @@
 
 from ..common import fileutil
 import os
+import gzip
 import re
 import collections
 from flask import abort
@@ -75,9 +76,9 @@ def calculate_stack_range(filename):
     # read .gz files via a "gunzip -c" pipe
     if filename.endswith(".gz"):
         try:
-            f = os.popen("gunzip -c " + path)
+            f = gzip.open(path, 'rt')
         except Exception:
-            print("ERROR: Can't gunzip -c stack file, %s." % path)
+            print("ERROR: Can't open gzipped file, %s." % path)
             f.close()
             return abort(500)
     else:


### PR DESCRIPTION
Performance impact appears minimal

    ```
    import timeit
    print(timeit.timeit('calculate_stack_range("perf.stacks01")',
          setup='from app.util.stack import calculate_stack_range'))
    print(timeit.timeit('read_offsets("perf.stacks01")',
          setup='from app.util.heatmap import read_offsets'))
    ```