### PR TITLE
Compile regex once at startup

### DIFF
--- a/app/common/fileutil.py
+++ b/app/common/fileutil.py
@@ -19,10 +19,10 @@
 
 import os
 import re
+invalidchars = re.compile('[^a-zA-Z0-9.,/_%+: -]')
 
 def validpath(pathname):
-    invalidchars = '[^a-zA-Z0-9.,/_%+: -]'
-    if re.search(invalidchars, pathname):
+    if invalidchars.search(pathname):
         return False
     if not os.path.exists(pathname):
         return False

--- a/app/util/heatmap.py
+++ b/app/util/heatmap.py
@@ -19,7 +19,6 @@
 
 from ..common import fileutil
 import os
-import re
 import collections
 from os.path import abspath, join
 from math import ceil, floor
@@ -84,11 +83,11 @@ def read_offsets(filename):
     for line in f:
         if (line[0] == '#'):
             continue
-        r = re.search(event_regexp, line)
+        r = event_regexp.search(line)
         if (r):
             if (stack != ""):
                 # process prior stack
-                if (not re.search(idle_regexp, stack)):
+                if (not idle_regexp.search(stack)):
                     offsets.append(ts)
                 # don't try to cache stacks (could be many Gbytes):
                 stack = ""
@@ -99,7 +98,7 @@ def read_offsets(filename):
         else:
             stack += line.rstrip()
     # last stack
-    if (not re.search(idle_regexp, stack)):
+    if (not idle_regexp.search(stack)):
         offsets.append(ts)
     if (ts > end):
         end = ts

--- a/app/util/regexp.py
+++ b/app/util/regexp.py
@@ -1,3 +1,4 @@
+import re
 #
 # Parsing
 #
@@ -71,11 +72,11 @@
 #
 # This event_regexp matches the event line, and puts time in the first group:
 #
-event_regexp = " +([0-9.]+): .+?:"
-frame_regexp = "^[\t ]*[0-9a-fA-F]+ (.+) \((.*)\)"
-comm_regexp = "^ *([^0-9]+)"
+event_regexp = re.compile(" +([0-9.]+): .+?:")
+frame_regexp = re.compile("^[\t ]*[0-9a-fA-F]+ (.+) \((.*)\)")
+comm_regexp = re.compile("^ *([^0-9]+)")
 
 # idle stack identification. just a regexp for now:
-idle_process = "swapper"
-idle_stack = "(cpuidle|cpu_idle|cpu_bringup_and_idle|native_safe_halt|xen_hypercall_sched_op|xen_hypercall_vcpu_op)"
-idle_regexp = "%s.*%s" % (idle_process, idle_stack)
+idle_process = re.compile("swapper")
+idle_stack = re.compile("(cpuidle|cpu_idle|cpu_bringup_and_idle|native_safe_halt|xen_hypercall_sched_op|xen_hypercall_vcpu_op)")
+idle_regexp = re.compile("%s.*%s" % (idle_process.pattern, idle_stack.pattern))

--- a/app/util/stack.py
+++ b/app/util/stack.py
@@ -19,7 +19,6 @@
 
 from ..common import fileutil
 import os
-import re
 import collections
 from flask import abort
 from os import walk
@@ -99,7 +98,7 @@ def calculate_stack_range(filename):
         # and makes a large difference.
         if (line[0] == '#' or line[0] == '\t'):
             continue
-        r = re.search(event_regexp, line)
+        r = event_regexp.search(line)
         if (r):
             ts = float(r.group(1))
             if ((linenum % index_factor) == 0):
@@ -251,14 +250,14 @@ def generate_stack(filename, range_start=None, range_end=None):
         # makes a big difference.
         r = None
         if (line[0] != '\t'):
-            r = re.search(event_regexp, line)
+            r = event_regexp.search(line)
         if (r):
             if (stack):
                 # process prior stack
                 stackstr = ""
                 for pair in stack:
                     stackstr += pair[0] + ";"
-                if (re.search(idle_regexp, stackstr)):
+                if (idle_regexp.search(stackstr)):
                     # skip idle
                     stack = []
                 elif (ts >= start and ts <= end):
@@ -267,14 +266,14 @@ def generate_stack(filename, range_start=None, range_end=None):
             ts = float(r.group(1))
             if (ts > end + overscan):
                 break
-            r = re.search(comm_regexp, line)
+            r = comm_regexp.search(line)
             if (r):
                 comm = r.group(1).rstrip()
                 stack.append([comm, ""])
             else:
                 stack.append(["<unknown>", ""])
         else:
-            r = re.search(frame_regexp, line)
+            r = frame_regexp.search(line)
             if (r):
                 name = r.group(1)
                 # strip instruction offset (+0xfe200...)


### PR DESCRIPTION
Small performance fix to only compile regex once rather than at every
invocation