### PR TITLE
fix to allow to run the app on windows

### DIFF
--- a/app/util/heatmap.py
+++ b/app/util/heatmap.py
@@ -24,6 +24,7 @@ import collections
 from os.path import abspath, join
 from math import ceil, floor
 from flask import abort
+from pathlib import Path
 
 from app import config
 from .regexp import event_regexp, idle_regexp
@@ -45,7 +46,7 @@ def read_offsets(filename):
         print("ERROR: File %s is not in STACK_DIR" % path)
         return abort(404)
 
-    if not fileutil.validpath(path):
+    if not Path(path).exists():
         return abort(500)
 
     # fetch modification timestamp and check cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
-click==6.7
-Flask==0.12.2
-itsdangerous==0.24
-Jinja2==2.10
-MarkupSafe==1.0
-Werkzeug==0.14.1
+click (6.7)
+Flask (0.12.2)
+itsdangerous (0.24)
+Jinja2 (2.10)
+MarkupSafe (1.0)
+pathlib (1.0.1)
+pip (9.0.3)
+setuptools (39.0.1)
+Werkzeug (0.14.1)
+wheel (0.31.0)


### PR DESCRIPTION
due to valid file path check regular expression, examples were not loading on windows.
For windows path, it contains **\\** which is a part of valid path check in fileutils files.