### PR TITLE
Fix stack parsing for Go lambdas

### DIFF
--- a/app/util/stack.py
+++ b/app/util/stack.py
@@ -281,10 +281,6 @@ def generate_stack(filename, range_start=None, range_end=None):
                 c = name.find("+")
                 if (c > 0):
                     name = name[:c]
-                # strip symbol args (...):
-                c = name.find("(")
-                if (c > 0):
-                    name = name[:c]
                 stack.insert(1, [name, r.group(2)])
     # last stack
     if (ts >= start and ts <= end):


### PR DESCRIPTION
The stack parsing code drops Golang stacks with names of the form "(...)". 

<details>
<summary> example repro </summary>

Before: `github.com/m3db/m3db/vendor/github.com/m3db/m3x/pool.`
![before](https://user-images.githubusercontent.com/199982/38576064-05769048-3ccb-11e8-99e8-60f8e7d4eb6d.png)

After: `github.com/m3db/m3db/vendor/github.com/m3db/m3x/pool.(*objectPool).Put`
![after](https://user-images.githubusercontent.com/199982/38576074-0e35195c-3ccb-11e8-9406-725fb809d604.png)

</details>

NB: I don't know much about perf's output format so I'm not a 100% sure the logic I've changed is sound. Happy to update per feedback. 