### PR TITLE
feat: support for DTrace stack profiles

### DIFF
--- a/app/util/heatmap.py
+++ b/app/util/heatmap.py
@@ -92,9 +92,8 @@ def read_offsets(filename):
                     offsets.append(ts)
                 # don't try to cache stacks (could be many Gbytes):
                 stack = ""
-            # TODO:
-            # For DTrace, which produces integer millisecond timestamps, we have to divide by 1000.0 for this to work
-            # as expected
+            # For DTrace, which produces integer millisecond timestamps, we have to divide by 1000.0
+            # to convert to fractional seconds that are expected here
             if (r.group('DTrace')):
               ts = float(r.group('DTrace'))/1000.0
             else:

--- a/app/util/heatmap.py
+++ b/app/util/heatmap.py
@@ -92,7 +92,13 @@ def read_offsets(filename):
                     offsets.append(ts)
                 # don't try to cache stacks (could be many Gbytes):
                 stack = ""
-            ts = float(r.group(1))
+            # TODO:
+            # For DTrace, which produces integer millisecond timestamps, we have to divide by 1000.0 for this to work
+            # as expected
+            if (r.group('DTrace')):
+              ts = float(r.group('DTrace'))/1000.0
+            else:
+              ts = float(r.group('perf'))
             if (ts < start):
                 start = ts
             stack = line.rstrip()
@@ -139,7 +145,10 @@ def generate_heatmap(filename, rows=None):
     for ts in offsets:
         col = int(floor(ts - floor(start)))
         row = rows - int(floor(rows * (ts % 1))) - 1
-        values[col][row] += 1
+        try:
+          values[col][row] += 1
+        except:
+          print("col: {} row: {} maxvalue: {}".format(col,row,maxvalue))
         if (values[col][row] > maxvalue):
             maxvalue = values[col][row]
 

--- a/app/util/regexp.py
+++ b/app/util/regexp.py
@@ -96,8 +96,8 @@ event_regexp = re.compile(r"(?:^\s+?\S+\s+PID:\s+\d+\s+TID:\s+\d+\s+\[(?P<DTrace
 frame_regexp = re.compile(r"(?:^[\t ]*[0-9a-fA-F]+ (?P<perf_frame>.+) \((?P<perf_frame_lib>.*?)\)$)|"
                           r"(?:^\s+(?P<DTrace_stack_count>\d+)\n)|"
                           r"(?:^(?:(?P<DTrace_frame_lib_or_mod>[^`]+)`)?(?P<DTrace_frame>[^\n]+)\n)")
-comm_regexp = re.compile(r"(?:^ *(?P<perf_comm>[^0-9]+))|"
-                         r"(?:^\s+?(?P<DTrace_comm>\S+)\s+PID:\s+\d+\s+TID:)")
+comm_regexp = re.compile(r"(?:^\s+?(?P<DTrace_comm>\S+)\s+PID:\s+\d+\s+TID:)|"
+                         r"(?:^ *(?P<perf_comm>[^0-9]+))")
 
 # idle stack identification. just a regexp for now:
 idle_process = re.compile("(swapper|sched)")

--- a/app/util/regexp.py
+++ b/app/util/regexp.py
@@ -72,7 +72,10 @@ import re
 #
 # This event_regexp matches the event line, and puts time in the first group:
 #
-event_regexp = re.compile(" +([0-9.]+): .+?:")
+# Use named capture for event_regexp, for perf/bcc/DTrace, and use that match to determine
+# how to parse the stack frames, etc
+event_regexp = re.compile(r"(?:^\s+?\S+\s+PID:\s+\d+\s+TID:\s+\d+\s+\[(?P<DTrace>\d+)\]\n)|"
+                          r"(?: +(?P<perf>[0-9.]+): .+?:)")
 frame_regexp = re.compile("^[\t ]*[0-9a-fA-F]+ (.+) \((.*?)\)$")
 comm_regexp = re.compile("^ *([^0-9]+)")
 

--- a/app/util/regexp.py
+++ b/app/util/regexp.py
@@ -93,8 +93,9 @@ import re
 # how to parse the stack frames, etc
 event_regexp = re.compile(r"(?:^\s+?\S+\s+PID:\s+\d+\s+TID:\s+\d+\s+\[(?P<DTrace>\d+)\]\n)|"
                           r"(?: +(?P<perf>[0-9.]+): .+?:)")
-frame_regexp = re.compile(r"(?:^[\t ]*[0-9a-fA-F]+ (?P<perf_frame>.+) \((?P<perf_frame_src>.*?)\)$)|"
-                          r"(?:^(?:(?P<DTrace_frame_src>[^`]+)`)?(?P<DTrace_frame>[^\n]+)\n)")
+frame_regexp = re.compile(r"(?:^[\t ]*[0-9a-fA-F]+ (?P<perf_frame>.+) \((?P<perf_frame_lib>.*?)\)$)|"
+                          r"(?:^\s+(?P<DTrace_stack_count>\d+)\n)|"
+                          r"(?:^(?:(?P<DTrace_frame_lib_or_mod>[^`]+)`)?(?P<DTrace_frame>[^\n]+)\n)")
 comm_regexp = re.compile(r"(?:^ *(?P<perf_comm>[^0-9]+))|"
                          r"(?:^\s+?(?P<DTrace_comm>\S+)\s+PID:\s+\d+\s+TID:)")
 

--- a/app/util/regexp.py
+++ b/app/util/regexp.py
@@ -100,8 +100,8 @@ comm_regexp = re.compile(r"(?:^ *(?P<perf_comm>[^0-9]+))|"
                          r"(?:^\s+?(?P<DTrace_comm>\S+)\s+PID:\s+\d+\s+TID:)")
 
 # idle stack identification. just a regexp for now:
-idle_process = re.compile("swapper")
+idle_process = re.compile("(swapper|sched)")
 idle_stack = re.compile(r"(cpuidle|cpu_idle|cpu_bringup_and_idle|native_safe_halt|"
                         r"xen_hypercall_sched_op|xen_hypercall_vcpu_op|"
-                        r"cpu_halt)")
+                        r"cpu_halt|idle)")
 idle_regexp = re.compile("%s.*%s" % (idle_process.pattern, idle_stack.pattern))

--- a/app/util/stack.py
+++ b/app/util/stack.py
@@ -124,7 +124,7 @@ def library2type(library):
         return "kernel"
     if library.find("vmlinux") > 0:
         return "kernel"
-    return "user"
+    return "inline"
 
 # add a stack to the root tree
 def add_stack(root, stack, comm):


### PR DESCRIPTION
Wondering if this could be reviewed/refined and possibly folded in at some point.

Used named regex captures to allow perf, DTrace, and ultimately bcc profiles to be parsed.

Have provided an example DTrace profiling script, but can make it more generic as needed.

