### PR TITLE
feat: file-backed cache for heatmap

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -5,4 +5,5 @@ BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 STACK_DIR = 'examples'
 HOST = '0.0.0.0'
 PORT = 5000
+USE_HEATMAP_FILECACHE = True
 JSONIFY_PRETTYPRINT_REGULAR = False

--- a/app/util/heatmap.py
+++ b/app/util/heatmap.py
@@ -30,7 +30,6 @@ from app import config
 from .regexp import event_regexp, idle_regexp
 
 # global defaults
-USE_HEATMAP_FILECACHE = True
 YRATIO = 1000   # milliseconds
 DEFAULT_ROWS = 50
 heatmap_cache = {}
@@ -61,7 +60,7 @@ def read_offsets(filename):
             # use cached heatmap
             return heatmap_cache[path]
 
-    if USE_HEATMAP_FILECACHE and avail_heatmap_filecache(path):
+    if config.USE_HEATMAP_FILECACHE and avail_heatmap_filecache(path):
         fc = read_heatmap_filecache(path)
         if fc.mtime == mtime:
             return fc.heatmap
@@ -116,7 +115,7 @@ def read_offsets(filename):
     heatmap = collections.namedtuple('offsets', ['start', 'end', 'offsets'])(start, end, offsets)
     heatmap_cache[path] = heatmap
     heatmap_mtimes[path] = mtime
-    if USE_HEATMAP_FILECACHE:
+    if config.USE_HEATMAP_FILECACHE:
         write_heatmap_filecache(path, heatmap, mtime)
     return heatmap
 
@@ -133,7 +132,6 @@ def write_heatmap_filecache(path, heatmap, mtime):
 def read_heatmap_filecache(path):
     f = open(convert_path_to_filecache(path), 'rt')
     h = json.loads(f.read())
-    print('read', h)
     f.close()
     return collections.namedtuple('cache', ['heatmap', 'mtime'])(
             collections.namedtuple('offsets', ['start', 'end', 'offsets'])(h['start'], h['end'], h['offsets']),

--- a/app/util/heatmap.py
+++ b/app/util/heatmap.py
@@ -22,7 +22,7 @@ import os
 import gzip
 import collections
 import json
-from os.path import abspath, join, isfile
+from os.path import abspath, join, isfile, dirname, basename
 from math import ceil, floor
 from flask import abort
 
@@ -61,7 +61,7 @@ def read_offsets(filename):
             # use cached heatmap
             return heatmap_cache[path]
 
-    if USE_HEATMAP_FILECACHE and avail_heatmap_filecache(path, mtime):
+    if USE_HEATMAP_FILECACHE and avail_heatmap_filecache(path):
         fc = read_heatmap_filecache(path)
         if fc.mtime == mtime:
             return fc.heatmap
@@ -121,7 +121,7 @@ def read_offsets(filename):
     return heatmap
 
 def convert_path_to_filecache(path):
-    return path + '-heatmap-cache'
+    return dirname(path) + '/.' + basename(path) + '-heatmap-cache'
 
 
 def write_heatmap_filecache(path, heatmap, mtime):


### PR DESCRIPTION
In some use cases, avoiding parsing perf data for multiple times contributes flamescope server & its users. flamescope already has in-memory cache for analyzed perf data, and this PR adds file-backed one in case of in-memory cache miss.