### PR TITLE
use raw string for regex patterns: this may fix CI failure

### DIFF
--- a/app/util/regexp.py
+++ b/app/util/regexp.py
@@ -72,9 +72,9 @@ import re
 #
 # This event_regexp matches the event line, and puts time in the first group:
 #
-event_regexp = re.compile(" +([0-9.]+): .+?:")
-frame_regexp = re.compile("^[\t ]*[0-9a-fA-F]+ (.+) \((.*?)\)$")
-comm_regexp = re.compile("^ *([^0-9]+)")
+event_regexp = re.compile(r" +([0-9.]+): .+?:")
+frame_regexp = re.compile(r"^[\t ]*[0-9a-fA-F]+ (.+) \((.*?)\)$")
+comm_regexp = re.compile(r"^ *([^0-9]+)")
 
 # idle stack identification. just a regexp for now:
 idle_process = re.compile("swapper")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click==6.7
-Flask==0.12.2
+Flask==0.12.4
 itsdangerous==0.24
 Jinja2==2.10
 MarkupSafe==1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 flake8
-pytest
+pytest==3.6
 pytest-flask


### PR DESCRIPTION
> The solution is to use Python’s raw string notation for regular expression patterns
https://docs.python.org/2.7/library/re.html