### PR TITLE
feat: icicle layout

### DIFF
--- a/src/components/FlameGraph/FlameGraph.jsx
+++ b/src/components/FlameGraph/FlameGraph.jsx
@@ -54,13 +54,19 @@ class FlameGraph extends Component {
         ].forEach((k) => {
           this[k] = this[k].bind(this);
         });
+
+        const preferredLayout = () => {
+            if(localStorage.getItem('layout')){
+                return localStorage.getItem('layout');
+            } else return 'flame';
+        }
     
         this.state = {
           data: {},
           loading: false,
           chart: null,
           searchTerm: '',
-          layout: 'flame'
+          layout: preferredLayout()
         };
     }
 
@@ -130,6 +136,7 @@ class FlameGraph extends Component {
             .transitionDuration(750)
             .sort(true)
             .title('')
+            .inverted(this.state.layout == 'icicle')
 
         var details = document.getElementById("details")
         chart.details(details)
@@ -178,6 +185,7 @@ class FlameGraph extends Component {
             this.state.chart
                 .inverted(this.state.layout == 'icicle')
                 .resetZoom()
+            localStorage.setItem('layout', this.state.layout)
         })
     }
 

--- a/src/components/FlameGraph/FlameGraph.jsx
+++ b/src/components/FlameGraph/FlameGraph.jsx
@@ -18,7 +18,7 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { Dimmer, Loader, Divider, Container, Button, Input } from 'semantic-ui-react'
+import { Dimmer, Loader, Divider, Container, Button, Input, Dropdown } from 'semantic-ui-react'
 import { pushBreadcrumb, popBreadcrumb } from '../../actions/Navbar'
 import { connect } from 'react-redux'
 import { flamegraph } from 'd3-flame-graph'
@@ -50,6 +50,7 @@ class FlameGraph extends Component {
             'handleSearchClick',
             'handleOnKeyDown',
             'updateSearchQuery',
+            'handleLayoutChange',
         ].forEach((k) => {
           this[k] = this[k].bind(this);
         });
@@ -59,6 +60,7 @@ class FlameGraph extends Component {
           loading: false,
           chart: null,
           searchTerm: '',
+          layout: 'flame'
         };
     }
 
@@ -171,12 +173,32 @@ class FlameGraph extends Component {
         this.props.history.push({search: params.toString(),});
     }
 
+    handleLayoutChange(event, data) {
+        const newLayout = data.value
+        this.setState({layout: newLayout}, () => {
+            this.state.chart.inverted(this.state.layout == 'icicle')
+            select(`#flamegraph`)
+                .datum(this.state.data)
+                .call(this.state.chart)
+        })
+    }
+
     render() {
         const searchButton = 
         <Button color='red' size='small' onClick={this.handleSearchClick}>
             <Button.Content>Search</Button.Content>
         </Button>
-        
+        const layoutOptions = [
+            {
+                text: "Flame Layout",
+                value: "flame"
+            },
+            {
+                text: "Icicle Layout",
+                value: "icicle"
+            }
+        ]
+
         return (
             <div>
                 <Dimmer page inverted active={this.state.loading}>
@@ -184,6 +206,7 @@ class FlameGraph extends Component {
                 </Dimmer> 
                 <Container style={styles.container}>
                     <Container textAlign='right'>
+                        <Dropdown selection options={layoutOptions} onChange={this.handleLayoutChange} defaultValue={this.state.layout} />
                         <Button inverted color='red' size='small' onClick={this.handleResetClick}>
                             <Button.Content>
                                 Reset Zoom

--- a/src/components/FlameGraph/FlameGraph.jsx
+++ b/src/components/FlameGraph/FlameGraph.jsx
@@ -174,12 +174,10 @@ class FlameGraph extends Component {
     }
 
     handleLayoutChange(event, data) {
-        const newLayout = data.value
-        this.setState({layout: newLayout}, () => {
-            this.state.chart.inverted(this.state.layout == 'icicle')
-            select(`#flamegraph`)
-                .datum(this.state.data)
-                .call(this.state.chart)
+        this.setState({layout: data.value}, () => {
+            this.state.chart
+                .inverted(this.state.layout == 'icicle')
+                .resetZoom()
         })
     }
 

--- a/src/components/FlameGraph/FlameGraph.jsx
+++ b/src/components/FlameGraph/FlameGraph.jsx
@@ -26,7 +26,7 @@ import { select } from 'd3-selection'
 import 'd3-flame-graph/dist/d3-flamegraph.css'
 import './flamegraph.less'
 import queryString from 'query-string'
-import {layout} from '../../config.jsx'
+import { layout } from '../../config.jsx'
 
 const styles = {
     container: {

--- a/src/components/FlameGraph/FlameGraph.jsx
+++ b/src/components/FlameGraph/FlameGraph.jsx
@@ -26,6 +26,7 @@ import { select } from 'd3-selection'
 import 'd3-flame-graph/dist/d3-flamegraph.css'
 import './flamegraph.less'
 import queryString from 'query-string'
+import {layout} from '../../config.jsx'
 
 const styles = {
     container: {
@@ -58,7 +59,7 @@ class FlameGraph extends Component {
         const preferredLayout = () => {
             if(localStorage.getItem('layout')){
                 return localStorage.getItem('layout');
-            } else return 'flame';
+            } else return layout.flame;
         }
     
         this.state = {
@@ -136,7 +137,7 @@ class FlameGraph extends Component {
             .transitionDuration(750)
             .sort(true)
             .title('')
-            .inverted(this.state.layout == 'icicle')
+            .inverted(this.state.layout === layout.icicle)
 
         var details = document.getElementById("details")
         chart.details(details)
@@ -183,7 +184,7 @@ class FlameGraph extends Component {
     handleLayoutChange(event, data) {
         this.setState({layout: data.value}, () => {
             this.state.chart
-                .inverted(this.state.layout == 'icicle')
+                .inverted(this.state.layout === layout.icicle)
                 .resetZoom()
             localStorage.setItem('layout', this.state.layout)
         })
@@ -196,12 +197,12 @@ class FlameGraph extends Component {
         </Button>
         const layoutOptions = [
             {
-                text: "Flame Layout",
-                value: "flame"
+                text: "Flame",
+                value: layout.flame
             },
             {
-                text: "Icicle Layout",
-                value: "icicle"
+                text: "Icicle",
+                value: layout.icicle
             }
         ]
 
@@ -212,7 +213,7 @@ class FlameGraph extends Component {
                 </Dimmer> 
                 <Container style={styles.container}>
                     <Container textAlign='right'>
-                        <Dropdown selection options={layoutOptions} onChange={this.handleLayoutChange} defaultValue={this.state.layout} />
+                        <Dropdown selection options={layoutOptions} onChange={this.handleLayoutChange} defaultValue={this.state.layout} compact button />
                         <Button inverted color='red' size='small' onClick={this.handleResetClick}>
                             <Button.Content>
                                 Reset Zoom

--- a/src/config.jsx
+++ b/src/config.jsx
@@ -1,0 +1,4 @@
+export const layout = {
+    flame: 'flame',
+    icicle: 'icicle',
+}


### PR DESCRIPTION
This PR attempts to resolve #8 by adding a dropdown to select the layout of the flame-graph, with "flame" or "icicle" options. 

The icicle layout is drawn by setting [inverted ](https://github.com/spiermar/d3-flame-graph#inverted)on the flame graph. 

Dropdown is chosen as it will also be useful for/in case sunburst layout #45 would be incorporated as well. I plainly put the control next to reset button. We might need some cosmetic tweaking if it looks ugly. 

The chosen layout is stored to localstorage for persistence. 
