### PR TITLE
Update Dockerfile to Python 3.x on Alpine 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM python:2-alpine3.7
+FROM python:3-alpine3.8
 
 ADD app /app/app
 ADD run.py /app
 ADD requirements.txt /app
 
-RUN cd /app && \
-  pip install -r requirements.txt && \
+RUN apk add libmagic && \
+  cd /app && \
+  pip3 install -r requirements.txt && \
   mkdir /profiles && \
   sed -i -e s/127.0.0.1/0.0.0.0/g -e s~examples~/profiles~g app/config.py
 

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ $ cd flamescope
 $ docker build -t flamescope .
 ```
 
-The container expects the profiles to be bind-mounted into `/stacks` and listens on port 5000. To view profiles from `/tmp/stacks`, start the container with the following command:
+The container expects the profiles to be bind-mounted into `/profiles` and listens on port 5000. To view profiles from `/tmp/profiles`, start the container with the following command:
 
 ```
-$ docker run --rm -it -v /tmp/stacks:/stacks:ro -p 5000:5000 flamescope
+$ docker run --rm -it -v /tmp/profiles:/profiles:ro -p 5000:5000 flamescope
 ```
 
 Then access FlameScope on [http://127.0.0.1:5000](http://127.0.0.1:5000/)


### PR DESCRIPTION
- Update Dockerfile to Python 3.x on Alpine 3.8
- Install `libmagic` 

Fixes #66 