### PR TITLE
feat: support V8 CPU Profiler generated by Node.js apps

### DIFF
--- a/app/cpuprofile/chrome.py
+++ b/app/cpuprofile/chrome.py
@@ -22,6 +22,9 @@ def get_cpuprofiles(chrome_profile):
     profile_events = []
     open_chunked_profile = None
 
+    if "nodes" in chrome_profile:
+        return [chrome_profile]
+
     for row in chrome_profile:
         if row['ph'] == 'I' and row['name'] == 'CpuProfile':
             # older chrome profiles


### PR DESCRIPTION
V8 CPU Profiles of Node.js applications generated by using the inspector protocol will follow the format defined in https://chromedevtools.github.io/devtools-protocol/v8/Profiler#type-Profile, which is the same format we use for each element of the array returned by `get_cpuprofiles`. We can identify the format is correct by checking if the key "nodes" is present.