### PR TITLE
support node.stack in nflxprofile format

### DIFF
--- a/app/common/flame_graph.py
+++ b/app/common/flame_graph.py
@@ -27,13 +27,18 @@ def _get_regular_stacks(nflxprofile_nodes, root_node_id):
     while queue:
         (nflxprofile_node_id, parent_node_id) = queue.pop(0)
         nflxprofile_node = nflxprofile_nodes[nflxprofile_node_id]
-        if not parent_node_id:
-            stacks[nflxprofile_node_id] = [
-                (nflxprofile_node.function_name, nflxprofile_node.libtype)
-            ]
+
+        if parent_node_id:
+            stacks[nflxprofile_node_id] = stacks[parent_node_id]
         else:
-            stacks[nflxprofile_node_id] = stacks[parent_node_id] + \
-                [(nflxprofile_node.function_name, nflxprofile_node.libtype)]
+            stacks[nflxprofile_node_id] = []
+
+        if nflxprofile_node.stack:
+            for frame in nflxprofile_node.stack:
+                stacks[nflxprofile_node_id].append((frame.function_name, frame.libtype))
+        else:
+            stacks[nflxprofile_node_id].append((nflxprofile_node.function_name, nflxprofile_node.libtype))
+
         for child_id in nflxprofile_node.children:
             queue.append((child_id, nflxprofile_node_id))
 


### PR DESCRIPTION
This patch adds support for `node.stack` in nflxprofile.

The nflxprofile format [supports](https://github.com/Netflix/nflxprofile/blob/master/nflxprofile.proto) attaching a list of stack frames to a node. As far as I can tell, this is currently ignored by flamescope, which expects one node per stack frame.

This patch will use the `node.stack` if present, and otherwise fall back to the node-level value.

A sample profile is attached (needs to be gunzipped to work).

[test.nflxprofile.gz](https://github.com/Netflix/flamescope/files/4421426/test.nflxprofile.gz)
