### PR TITLE
Update Build Status Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![FlameScope](docs/screenshot-flamescope-02-annotated.png)
 
 [![Gitter](https://badges.gitter.im/gitterHQ/gitter.svg)](https://gitter.im/flamescope)
-[![TravisCI](https://img.shields.io/travis/Netflix/flamescope.svg)](https://travis-ci.org/Netflix/flamescope)
+[![TravisCI](https://travis-ci.com/Netflix/flamescope.svg)](https://travis-ci.com/Netflix/flamescope)
 [![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/Netflix/flamescope.svg)]()
 [![License](https://img.shields.io/github/license/Netflix/flamescope.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 flake8
-pytest==3.6
+pytest==5.2
 pytest-flask


### PR DESCRIPTION
This change updates the link for the build status image in the README. TravisCI is shutting down travis-ci.org at the end of the year. The build has been migrated to travis-ci.com at their [recommendation](https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom).

A separate commit updates the pytest version, which failed in [the most recent build](https://travis-ci.org/github/Netflix/flamescope/jobs/667487505) with error message:
> pytest-flask 1.0.0 has requirement pytest>=5.2, but you'll have pytest 3.6.0 which is incompatible.

I tried to follow the commit message formatting conventions in the repository. Happy to make any changes.