### PR TITLE
Bug fix: populate heatmap offset cache

### DIFF
--- a/app/controllers/heatmap.py
+++ b/app/controllers/heatmap.py
@@ -42,16 +42,23 @@ def _read_offsets(file_path, file_type):
         if mtime == offsets_mtimes[file_path]:
             # use cached heatmap
             return offsets_cache[file_path]
+    offsets = None
     if file_type == 'perf':
-        return perf_read_offsets(file_path)
+        offsets = perf_read_offsets(file_path)
     elif file_type == 'cpuprofile':
-        return cpuprofile_read_offsets(file_path)
+        offsets =  cpuprofile_read_offsets(file_path)
     elif file_type == 'trace_event':
-        return trace_event_read_offsets(file_path, mtime)
+        offsets = trace_event_read_offsets(file_path, mtime)
     elif file_type == 'nflxprofile':
-        return nflxprofile_readoffsets(file_path)
+        offsets = nflxprofile_readoffsets(file_path)
     else:
         raise InvalidFileError('Unknown file type.')
+    if offsets is None:
+	    raise RuntimeError('Offsets parse error.')
+    offsets_cache[file_path] = offsets
+    offsets_mtimes[file_path] = mtime
+    return offsets
+
 
 
 # return a heatmap from the cached offsets


### PR DESCRIPTION
Populates `offsets_cache` and `offsets_mtimes` as originially intended.

Before this patch returning from the flamegraph view to the heatmap view would require recomputing offsets meaning the page would take N seconds to load for a large profile.

After this patch loading the heatmap view is instant after the initial load.

Closes #141